### PR TITLE
Fix deprecated api

### DIFF
--- a/TENSORBOX/utils/train_utils.py
+++ b/TENSORBOX/utils/train_utils.py
@@ -206,11 +206,16 @@ def interp(w, i, channel_dim):
         of the same length == len(i)
     '''
     w_as_vector = tf.reshape(w, [-1, channel_dim]) # gather expects w to be 1-d
-    upper_l = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.floor(i[:, 2:3])]))
-    upper_r = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.ceil(i[:, 2:3])]))
-    lower_l = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.floor(i[:, 2:3])]))
-    lower_r = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.ceil(i[:, 2:3])]))
-
+    if(int(tf.__version__.split(".")[1])<13 and int(tf.__version__.split(".")[0])<2): ### for tf version < 13
+        upper_l = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.floor(i[:, 2:3])]))
+        upper_r = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.ceil(i[:, 2:3])]))
+        lower_l = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.floor(i[:, 2:3])]))
+        lower_r = tf.to_int32(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.ceil(i[:, 2:3])]))
+    else:  ### for tf version >= 13
+        upper_l = tf.cast(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.floor(i[:, 2:3])]),tf.int32)
+        upper_r = tf.cast(tf.concat(1, [i[:, 0:1], tf.floor(i[:, 1:2]), tf.ceil(i[:, 2:3])]),tf.int32)
+        lower_l = tf.cast(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.floor(i[:, 2:3])]),tf.int32)
+        lower_r = tf.cast(tf.concat(1, [i[:, 0:1], tf.ceil(i[:, 1:2]), tf.ceil(i[:, 2:3])]),tf.int32)
     upper_l_idx = to_idx(upper_l, tf.shape(w))
     upper_r_idx = to_idx(upper_r, tf.shape(w))
     lower_l_idx = to_idx(lower_l, tf.shape(w))
@@ -265,6 +270,8 @@ def bilinear_select(H, pred_boxes, early_feat, early_feat_channels, w_offset, h_
     pred_y_center_clip = tf.clip_by_value(pred_y_center,
                                           0,
                                           scale_factor * H['grid_height'] - 1)
-
-    interp_indices = tf.concat(1, [tf.to_float(batch_ids), pred_y_center_clip, pred_x_center_clip])
+    if(int(tf.__version__.split(".")[1])<13 and int(tf.__version__.split(".")[0])<2): ### for tf version < 1.13
+        interp_indices = tf.concat(1, [tf.to_float(batch_ids), pred_y_center_clip, pred_x_center_clip])
+    else: ### for tf version >= 1.13.0
+        interp_indices = tf.concat(1, [tf.cast(batch_ids,tf.float32), pred_y_center_clip, pred_x_center_clip]) 
     return interp_indices

--- a/Utils_Tensorbox.py
+++ b/Utils_Tensorbox.py
@@ -382,8 +382,10 @@ def bbox_det_TENSORBOX_multiclass(frames_list,path_video_folder,hypes_file,weigh
 
     with tf.Session() as sess:
 
-
-        sess.run(tf.initialize_all_variables())
+        if(int(tf.__version__.split(".")[0])==0 and int(tf.__version__.split(".")[1])<12): ### for tf v<0.12.0
+            sess.run(tf.initialize_all_variables())
+        else: ### for tf v>=0.12.0
+            sess.run(tf.global_variables_initializer())
         saver.restore(sess, weights_file )##### Restore a Session of the Model to get weights and everything working
     
         #### Starting Evaluating the images

--- a/YOLO/YOLO_small_tf.py
+++ b/YOLO/YOLO_small_tf.py
@@ -76,7 +76,10 @@ class YOLO_TF:
 		#skip dropout_31
 		self.fc_32 = self.fc_layer(32,self.fc_30,1470,flat=False,linear=True)
 		self.sess = tf.Session()
-		self.sess.run(tf.initialize_all_variables())
+		if(int(tf.__version__.split(".")[0])==0 and int(tf.__version__.split(".")[1])<12): ### for tf v<0.12.0
+			self.sess.run(tf.initialize_all_variables())
+		else:
+			self.sess.run(tf.global_variables_initializer())
 		self.saver = tf.train.Saver()
 		self.saver.restore(self.sess,self.weights_file)
 		if self.disp_console : print "Loading complete!" + '\n'

--- a/YOLO/YOLO_tiny_tf.py
+++ b/YOLO/YOLO_tiny_tf.py
@@ -63,7 +63,10 @@ class YOLO_TF:
 		#skip dropout_18
 		self.fc_19 = self.fc_layer(19,self.fc_17,1470,flat=False,linear=True)
 		self.sess = tf.Session()
-		self.sess.run(tf.initialize_all_variables())
+		if(int(tf.__version__.split(".")[0])==0 and int(tf.__version__.split(".")[1])<12): ### for tf v<0.12.0
+			self.sess.run(tf.initialize_all_variables())
+		else:
+			self.sess.run(tf.global_variables_initializer())	
 		self.saver = tf.train.Saver()
 		self.saver.restore(self.sess,self.weights_file)
 		if self.disp_console : print "Loading complete!" + '\n'


### PR DESCRIPTION
Hi developers,

I also found some potential detrimental deprecated api usag below:

`tf.scalar_summary`,`tf.histogram_summary`,`tf.merge_all_summaries`,`tf.histogram_summary` have been deprecated in tf v0.12.0 and **removed in tf v1.0.0**. It's better to replace it with apis in `tf.summary`

`tf.initialize_all_variables` has been deprecated in tf v0.12.0 and should be replaced with `tf.global_variables_initializer`

I think this will help make this code more compatible !

@DrewNF 
Hope you could take my advice and look forward to your reply! 😃